### PR TITLE
fix(node-red-s1seven-api): use `replace` String method with regex

### DIFF
--- a/packages/node-red-s1seven-api/lib/utils/keys.js
+++ b/packages/node-red-s1seven-api/lib/utils/keys.js
@@ -15,7 +15,7 @@ const {
  * @returns {string}
  */
 function getConfigNodeIdentifier(configNode) {
-  return configNode.name ? configNode.name.replaceAll(' ', '_') : configNode.id;
+  return configNode.name ? configNode.name.replace(/ /g, '_') : configNode.id;
 }
 
 /**


### PR DESCRIPTION
# Description

String `replaceAll` is only available starting from node 15, use `replace` with Regex instead.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
